### PR TITLE
Root Namespaceの設定を追加

### DIFF
--- a/FIS-J/FIS-J/FIS-J.csproj
+++ b/FIS-J/FIS-J/FIS-J.csproj
@@ -1,8 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+    <RootNamespace>FIS_J</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
ファイルを新規作成したときに, 「FIS-J」のようにハイフン付きで名前空間が設定されるバグを防ぐため