### PR TITLE
空港PinのAnchorを0に設定

### DIFF
--- a/FIS-J/Maps/AirportMap.cs
+++ b/FIS-J/Maps/AirportMap.cs
@@ -54,6 +54,8 @@ public class AirportMap : AirMap
 
 				Scale = 0.5f,
 
+				Anchor = new(0, 0),
+
 				Svg = svg_str,
 			};
 


### PR DESCRIPTION
resolve #50

デフォルトのAnchorが`(x,y)=(0,28)`に設定されているため、それを無効化する形。
ref: https://github.com/Mapsui/Mapsui/blob/54fb1786543bb160d32c479db0e13a92af3419b2/Mapsui.UI.Forms/Objects/Pin.cs#L56