### PR TITLE
iOS Simulatorでもデバッグできるように修正

### DIFF
--- a/FIS-J/FIS-J.csproj
+++ b/FIS-J/FIS-J.csproj
@@ -21,7 +21,6 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
-		<RuntimeIdentifier Condition="'$(TargetFramework)' == 'net6.0-ios'">ios-arm64</RuntimeIdentifier>
 	</PropertyGroup>
 	<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<WarningLevel>4</WarningLevel>


### PR DESCRIPTION
4fb417d1a86c95ef31a89d1516ec362199a8e640 で追加してるけど、これは元々Xamarin.iOS向けのものを適当にコピーしただけなので、このときにsimulator向け設定をコピペし忘れたものと思われる。

下手にRuntimeIdentifierとして`iossimulator-x64`を追加すると実機デバッグができなくなってしまうため、削除で対応する。
もし不具合があれば、そのときにまた対応を検討する。