### PR TITLE
LonLat Lines in One Layer

### DIFF
--- a/FIS-J/Components/Maps/Layers/LatLngLayer.cs
+++ b/FIS-J/Components/Maps/Layers/LatLngLayer.cs
@@ -16,6 +16,8 @@ namespace FIS_J.Components.Maps.Layers
 		public const int LON_LINE_MAX = 180;
 		const double DEFAULT_OPACITY = 0.2;
 
+		const int STEP_PRECISION = 100;
+
 		static Pen DashPen { get; } = new()
 		{
 			Color = Mapsui.Styles.Color.Black,
@@ -73,6 +75,9 @@ namespace FIS_J.Components.Maps.Layers
 
 			bool isSkipStepNaN = double.IsNaN(skipStep);
 
+			int I_Step = (int)(step * STEP_PRECISION);
+			int I_SkipStep = isSkipStepNaN ? int.MaxValue : (int)(skipStep * STEP_PRECISION);
+
 			VectorStyle style = new()
 			{
 				Fill = null,
@@ -98,35 +103,37 @@ namespace FIS_J.Components.Maps.Layers
 				latlngLines.Add(feature);
 			}
 
-			for (double i = 0; i <= 180; i += step)
+			for (int i = 0; i <= LON_LINE_MAX * STEP_PRECISION; i += I_Step)
 			{
-				if (!isSkipStepNaN && (i % skipStep) == 0)
+				if (!isSkipStepNaN && (i % I_SkipStep) == 0)
 					continue;
 
+				double value = (double)i / (double)STEP_PRECISION;
 				// positive longitude
 				AddNewLine(
-					i, -LAT_LINE_MAX,
-					i, LAT_LINE_MAX
+					value, -LAT_LINE_MAX,
+					value, LAT_LINE_MAX
 					);
 				if (i == 0)
 					continue;
 
 				// negative longitude
 				AddNewLine(
-					-i, -LAT_LINE_MAX,
-					-i, LAT_LINE_MAX
+					-value, -LAT_LINE_MAX,
+					-value, LAT_LINE_MAX
 					);
 			}
 
-			for (double i = 0; i <= LAT_LINE_MAX; i += step)
+			for (int i = 0; i <= LAT_LINE_MAX * STEP_PRECISION; i += I_Step)
 			{
-				if (!isSkipStepNaN && (i % skipStep) == 0)
+				if (!isSkipStepNaN && (i % I_SkipStep) == 0)
 					continue;
 
+				double value = (double)i / (double)STEP_PRECISION;
 				// positive latitude
 				AddNewLine(
-					-LON_LINE_MAX, i,
-					LON_LINE_MAX, i
+					-LON_LINE_MAX, value,
+					LON_LINE_MAX, value
 					);
 
 				if (i == 0)
@@ -134,8 +141,8 @@ namespace FIS_J.Components.Maps.Layers
 
 				// negative latitude
 				AddNewLine(
-					-LON_LINE_MAX, -i,
-					LON_LINE_MAX, -i
+					-LON_LINE_MAX, -value,
+					LON_LINE_MAX, -value
 					);
 			}
 


### PR DESCRIPTION
緯度経度の線について、これまでは複数レイヤーを使用して実現していた。
しかし、レイヤーの選択表示機能を実装したことにより、何枚も同じような役割のレイヤーが表示される事態になってしまった。
そこで、各線にStyleを適用することで、レイヤーが1枚で済むようにした。

このほか、以下の修正を行なった。

- 緯度経度の線が重なって濃く表示されるバグを修正
- 線の太さを調整
- 最短間隔な線について、波線で表示するように変更

起動時の表示イメージ
![simulator_screenshot_7FCAD7E9-DEE0-4064-B524-C19E503F0BBC](https://user-images.githubusercontent.com/31824852/180740933-55d05fbc-1efe-4207-a9f1-f7d171147962.png)

Resolution 1000~5000での表示イメージ
![simulator_screenshot_3B5CACE3-B464-4B49-BE96-5BA6481C5863](https://user-images.githubusercontent.com/31824852/180741189-a2035fc8-959c-45dc-a359-94fd6d25649e.png)

レイヤー選択画面での表示イメージ
![simulator_screenshot_F9F2BDBD-7ADE-4837-A664-814D18C9A4AC](https://user-images.githubusercontent.com/31824852/180741430-0c0a6c03-c241-4a44-91ce-c63f75d9c7cd.png)

