### PR TITLE
[TopPage/Map] 設定Popupの表示調整

### DIFF
--- a/AirTote/Components/Maps/MapSettingPopup.xaml.cs
+++ b/AirTote/Components/Maps/MapSettingPopup.xaml.cs
@@ -15,9 +15,10 @@ public partial class MapSettingPopup : Popup
 		// code from: https://github.com/CommunityToolkit/Maui/blob/68b82412a7e31d961b7ec0da2909f38e2a07ff9a/samples/CommunityToolkit.Maui.Sample/Models/PopupSize.cs#L10
 		var deviceDisplay = DeviceDisplay.Current;
 		Size = new(
-			0.9 * (deviceDisplay.MainDisplayInfo.Width / deviceDisplay.MainDisplayInfo.Density),
+			Math.Min(0.9 * (deviceDisplay.MainDisplayInfo.Width / deviceDisplay.MainDisplayInfo.Density), 350),
 			0.8 * (deviceDisplay.MainDisplayInfo.Height / deviceDisplay.MainDisplayInfo.Density)
 			);
+		this.HorizontalOptions = Microsoft.Maui.Primitives.LayoutAlignment.Start;
 
 		InitializeComponent();
 


### PR DESCRIPTION
Popupが大きすぎるため、最大幅を制限したうえで左寄せで表示させるようにした

![simulator_screenshot_437549F6-1FEF-4F6F-B0A7-BF8E15AB5972](https://user-images.githubusercontent.com/31824852/183135487-3fdac312-e3ab-4457-9269-c548d30acbcc.png)
