### PR TITLE
Actions Support WIP

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -23,7 +23,7 @@ jobs:
       !startsWith(github.ref, 'refs/tags/bundle')
       && (
         github.event_name != 'pull_request'
-        || (github.event.action != 'unlabeled' && !contains(github.event.pull_request.labels, 'WIP'))
+        || (github.event.action != 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'WIP'))
         || (github.event.action == 'unlabeled' && github.event.label.name == 'WIP')
       )
 
@@ -91,7 +91,7 @@ jobs:
       )
       && (
         github.event_name != 'pull_request'
-        || (github.event.action != 'unlabeled' && !contains(github.event.pull_request.labels, 'WIP'))
+        || (github.event.action != 'unlabeled' && !contains(github.event.pull_request.labels.*.name, 'WIP'))
         || (github.event.action == 'unlabeled' && github.event.label.name == 'WIP')
       )
 


### PR DESCRIPTION
作業中を表す`WIP`ラベルを付けているPRに関しては、自動デプロイを走らせないように設定した

これにより、PRで協議をしてからmergeしたい等の需要に応える。