### PR TITLE
Make Action Portable

### DIFF
--- a/.github/workflows/cd-action.yml
+++ b/.github/workflows/cd-action.yml
@@ -251,7 +251,7 @@ jobs:
         retention-days: 3
 
     - name: Post 'Import Code Sign Certificates'
-      if: steps.import-code-sign-cert.conclusion == 'success'
+      if: always() && steps.import-code-sign-cert.conclusion == 'success'
       run: /usr/bin/security delete-keychain ${{ steps.gen-keychain-name.outputs.keychain-name }}.keychain
 
   set-tag:


### PR DESCRIPTION
マシンに証明書や鍵をインストールする作業が面倒になったため、その辺もWorkflowに含めることで、GitHub Hosted Runnerでも動作できるようにした。

実際にはself-hosted runnerで動作させる。