### PR TITLE
Fix NavBar Title Color

### DIFF
--- a/AirTote/App.xaml
+++ b/AirTote/App.xaml
@@ -57,14 +57,6 @@
 				x:Key="LightDarkBGRect"
 				BasedOn="{StaticResource LightDarkBG}" />
 
-			<Style TargetType="NavigationPage">
-				<Setter
-					Property="BarTextColor"
-					Value="{AppThemeBinding Light={StaticResource LightSecondaryColor}, Dark={StaticResource DarkSecondaryColor}}" />
-				<Setter
-					Property="BarBackground"
-					Value="{AppThemeBinding Light={StaticResource LightBackgroundColor}, Dark={StaticResource DarkBackgroundColor}}" />
-			</Style>
 			<Style TargetType="Button">
 				<Setter
 					Property="Margin"


### PR DESCRIPTION
resolves #90

ライトモードでも正常に文字が表示されるようになった。

ついでに、廃止した`NavigationPage`用の設定も不要なので削除した